### PR TITLE
Fixes #9

### DIFF
--- a/src/twitter/core.clj
+++ b/src/twitter/core.clj
@@ -43,7 +43,7 @@
 (defn default-client 
   "makes a default async client for the http comms"
   []
-  (memo-create-client :follow-redirects false))
+  (memo-create-client :follow-redirects false :request-timeout -1))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
The latest http.async client quits after the default timeout of 60s elapses.
A setting of -1 turns this "feature" off. :)
