### PR TITLE
Bump Twitter Search API to v1.1

### DIFF
--- a/src/twitter/api/search.clj
+++ b/src/twitter/api/search.clj
@@ -6,7 +6,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def ^:dynamic *search-api* (ApiContext. "http" "search.twitter.com" nil))
+(def ^:dynamic *search-api* (ApiContext. "https" "api.twitter.com" "1.1"))
 
 (defmacro def-twitter-search-method
   "defines a search method using the search api context and the synchronous comms"
@@ -16,6 +16,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def-twitter-search-method search :get "search.json")
+(def-twitter-search-method search :get "search/tweets.json")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This is a super simple pull request that bumps the Twitter Search API to [v1.1](https://dev.twitter.com/docs/api/1.1/get/search/tweets). The new version basically just returns Tweet objects more similar to the objects found across the Twitter REST API. 

cc: @danhammer
