### PR TITLE
Add statuses-update example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ All of the API calls will return the full HTTP response of the request, includin
                                                   exception-rethrow)      
 	      :params {:target-screen-name "AdamJWynne"})
 
+; post a text status, using the default sync-single callback
+(statuses-update :oauth-creds *creds*
+                 :params {:status "hello world"})
+
 ; upload a picture tweet with a text status attached, using the default sync-single callback
 (statuses-update-with-media :oauth-creds *creds*
                             :body [(file-body-part "/pics/test.jpg")


### PR DESCRIPTION
Including an example for `statuses-update-with-media` but not `statuses-update` may seem to imply that they take the same arguments - but they don't. Let's add an extra example that makes that immediately clear.
