### PR TITLE
Add application-only authentication option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,7 @@
   :description "full twitter api async interface"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/data.json "0.2.5"]
+                 [org.clojure/data.codec "0.1.0"]
                  [http.async.client "0.5.2"]
                  [clj-oauth "1.5.1"]]
   :url "https://github.com/adamwynne/twitter-api"

--- a/src/twitter/core.clj
+++ b/src/twitter/core.clj
@@ -63,10 +63,12 @@
 
         final-uri (subs-uri uri params)
         
-        oauth-map (sign-query (:oauth-creds arg-map)
-                              verb
-                              final-uri
-                              :query query)
+        oauth-map (if (contains? (:oauth-creds arg-map) :bearer)
+                    (:oauth-creds arg-map) ;; no need to sign for app-only auth
+                    (sign-query (:oauth-creds arg-map)
+                                verb
+                                final-uri
+                                :query query))
         
         headers (merge (:headers arg-map)
                        (if oauth-map {:Authorization (oauth-header-string oauth-map)}))

--- a/src/twitter/oauth.clj
+++ b/src/twitter/oauth.clj
@@ -2,6 +2,11 @@
   (:use
    [clojure.test])
   (:require
+   [http.async.client.request :as req]
+   [http.async.client :refer [create-client]]
+   [twitter.callbacks :refer [callbacks-sync-single-default]]
+   [twitter.request :refer [execute-request-callbacks]]
+   [clojure.data.codec.base64 :as b64]
    [oauth.client :as oa]
    [oauth.signature :as oas]))
 
@@ -31,28 +36,65 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn oauth-header-string 
-  "creates the string for the oauth header's 'Authorization' value, url encoding each value"
+  "Creates the string for the oauth header's 'Authorization' value,
+  url encoding each value. If the signing-map is an application-only
+  token, returns the 'Bearer' value."
   [signing-map & {:keys [url-encode?] :or {url-encode? true}}]
 
-  (let [val-transform (if url-encode? oas/url-encode identity)
-        s (reduce (fn [s [k v]] (format "%s%s=\"%s\"," s (name k) (val-transform (str v))))
-                  "OAuth "
-                  signing-map)]
-    (.substring s 0 (dec (count s)))))
+  (if-let [app-only-token (:bearer signing-map)]
+    (str "Bearer " app-only-token)
+    (let [val-transform (if url-encode? oas/url-encode identity)
+          s (reduce (fn [s [k v]] (format "%s%s=\"%s\"," s (name k) (val-transform (str v))))
+                    "OAuth "
+                    signing-map)]
+      (.substring s 0 (dec (count s))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- encode-app-only-key
+  "Given a consumer-key and consumer-secret, concatenates and Base64
+  encodes them so that they can be submitted to Twitter in exchange
+  for an application-only token."
+  [consumer-key consumer-secret]
+  (let [concat-keys (str (oas/url-encode consumer-key) ":" (oas/url-encode consumer-secret))]
+    (-> (.getBytes concat-keys)
+      b64/encode
+      (String. "UTF-8"))))
+
+(defn request-app-only-token
+  [consumer-key consumer-secret]
+  (let [auth-string (str "Basic " (encode-app-only-key consumer-key consumer-secret))
+        content-type "application/x-www-form-urlencoded;charset=UTF-8"
+        req (req/prepare-request :post, "https://api.twitter.com/oauth2/token"
+                                 :headers {"Authorization" auth-string
+                                           "Content-Type" content-type}
+                                 :body "grant_type=client_credentials")
+        client (create-client :follow-redirects false :request-timeout -1)
+        {:keys [status body]} (execute-request-callbacks client req (callbacks-sync-single-default))]
+    (if (= (:code status) 200)
+      {:bearer (:access_token body)}
+      (throw (Exception. (str "Failed to retrieve application-only due to an unknown error: " body))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn make-oauth-creds
-  "creates an oauth object out of supplied params"
-  [app-key app-secret user-token user-token-secret]
+  "Creates an oauth object out of supplied params. If only an app-key
+  and app-secret are supplied, this function will return an
+  application-only authentication token. If a user-key and
+  user-token-secret are also supplied, then it will return a fully
+  authenticated token."
 
-  (let [consumer (oa/make-consumer app-key
-                                   app-secret
-                                   "https://twitter.com/oauth/request_token"
-                                   "https://twitter.com/oauth/access_token"
-                                   "https://twitter.com/oauth/authorize"
-                                   :hmac-sha1)]
-        
-    (OauthCredentials. consumer user-token user-token-secret)))
+  ([app-key app-secret]
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+   (request-app-only-token app-key app-secret))
+
+  ([app-key app-secret user-token user-token-secret]
+
+   (let [consumer (oa/make-consumer app-key
+                                    app-secret
+                                    "https://twitter.com/oauth/request_token"
+                                    "https://twitter.com/oauth/access_token"
+                                    "https://twitter.com/oauth/authorize"
+                                    :hmac-sha1)]
+     
+     (OauthCredentials. consumer user-token user-token-secret))))

--- a/test/twitter/api/test/restful.clj
+++ b/test/twitter/api/test/restful.clj
@@ -13,6 +13,7 @@
 (deftest test-account
   (is-200 account-verify-credentials)
   (is-200 application-rate-limit-status)
+  (is-200 application-rate-limit-status :app-only)
   (is-200 account-settings))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -34,23 +35,29 @@
 (deftest test-statuses
   (let [status-id (get-current-status-id *user-screen-name*)]
     (is-200 statuses-show-id :params {:id status-id})
-    (is-200 statuses-retweets-id :params {:id status-id})))
+    (is-200 statuses-show-id :params {:id status-id} :app-only)
+    (is-200 statuses-retweets-id :params {:id status-id})
+    (is-200 statuses-retweets-id :params {:id status-id}) :app-only))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (deftest test-search
-  (is-200 search-tweets :params {:q "clojure"}))
+  (is-200 search-tweets :params {:q "clojure"})
+  (is-200 search-tweets :params {:q "clojure"} :app-only))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (deftest test-user
   (let [user-id (get-user-id *user-screen-name*)]
     (is-200 users-show :params {:user-id user-id})
+    (is-200 users-show :params {:user-id user-id} :app-only)
     (is-200 users-lookup :params {:user-id user-id})
+    (is-200 users-lookup :params {:user-id user-id} :app-only)
     (is-200 users-suggestions :params {:q "john smith"})
-    ;; AW - these seem down on 26/4/2013 - not sure whats up??
-    ;;(is-200 users-suggestions-slug :params {:slug "sports"})
-    ;;(is-200 users-suggestions-slug-members :params {:slug "sports"})
+    (is-200 users-suggestions :params {:q "john smith"} :app-only)
+    (is-200 users-suggestions-slug :params {:slug "sports"})
+    (is-200 users-suggestions-slug-members :params {:slug "sports"})
+    ;; The following test seems to be broken as of 23/12/14
     ;;(is-200 users-contributees :params {:user-id user-id})
 ))
 
@@ -58,8 +65,11 @@
 
 (deftest test-trends
   (is-200 trends-place :params {:id 1})
+  (is-200 trends-place :params {:id 1} :app-only)
   (is-200 trends-available)
-  (is-200 trends-closest :params {:lat 37.781157 :long -122.400612831116}))
+  (is-200 trends-available :app-only)
+  (is-200 trends-closest :params {:lat 37.781157 :long -122.400612831116})
+  (is-200 trends-closest :params {:lat 37.781157 :long -122.400612831116} :app-only))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -107,6 +117,7 @@
 
 (deftest test-friendship
   (is-200 friendships-show :params {:source-screen-name *user-screen-name* :target-screen-name "AdamJWynne"})
+  (is-200 friendships-show :params {:source-screen-name *user-screen-name* :target-screen-name "AdamJWynne"} :app-only)
   (is-200 friendships-lookup :params { :screen-name "peat,AdamJWynne" } )
   (is-200 friendships-incoming)
   (is-200 friendships-outgoing))

--- a/test/twitter/test/core.clj
+++ b/test/twitter/test/core.clj
@@ -17,7 +17,8 @@
 (deftest test-oauth-header-string
   (is (= (oauth-header-string {:a 1 :b 2 :c 3}) "OAuth c=\"3\",b=\"2\",a=\"1\""))
   (is (= (oauth-header-string {:a "hi there"}) "OAuth a=\"hi%20there\""))
-  (is (= (oauth-header-string {:a "hi there"} :url-encode? nil) "OAuth a=\"hi there\"")))
+  (is (= (oauth-header-string {:a "hi there"} :url-encode? nil) "OAuth a=\"hi there\""))
+  (is (= (oauth-header-string {:bearer "hello"}) "Bearer hello")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/test/twitter/test/creds.clj
+++ b/test/twitter/test/creds.clj
@@ -50,3 +50,10 @@
                     *user-access-token-secret*))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn make-app-only-test-creds
+  "makes an Oauth structure that uses only an app's credentials"
+  []
+
+  (make-oauth-creds *app-consumer-key*
+                    *app-consumer-secret*))

--- a/test/twitter/test_utils/core.clj
+++ b/test/twitter/test_utils/core.clj
@@ -23,11 +23,21 @@
 
   `(is (= (get-in (~fn-name :oauth-creds (make-test-creds) ~@args) [:status :code]) ~code)))
 
+(defmacro is-200-with-app-only
+  "checks to see if the response to a request using application-only
+  authentication is a specific HTTP return code"
+  [fn-name & args]
+
+  `(is (= (get-in (~fn-name :oauth-creds (make-app-only-test-creds) ~@args) [:status :code]) 200)))
+
 (defmacro is-200
   "checks to see if the response is HTTP 200"
   [fn-name & args]
 
-  `(is-http-code 200 ~fn-name ~@args))
+  (if (some #{:app-only} args)
+    (let [args# (remove #{:app-only} args)]
+      `(is-200-with-app-only ~fn-name ~@args#))
+    `(is-http-code 200 ~fn-name ~@args)))
 
 (defn get-user-id
   "gets the id of the supplied screen name"


### PR DESCRIPTION
For many endpoints, it's possible to authenticate with just the application credentials and no user credentials at all. In this case, the application has its own separate rate limit (sometimes higher than the user-authenticated version), so it's possible to make at least twice as many requests per 15-minute period if one uses both the application-only and user-authenticated credentials. See [Twitter's docs](https://dev.twitter.com/oauth/application-only).

This commit extends `make-oauth-creds` with a new arity that takes two arguments: the `app-key` and `app-secret`, returning the application-only token. The `get-request-args` and `oauth-header-string` functions are similarly extended to properly handle the application-only auth map.

Finally, the `is-200` macro is extended to take an optional `:app-only` arg, which causes the given function to be called with application-only credentials (see `make-app-only-test-creds`). I added additional tests using this macro where appropriate.
