### PR TITLE
Switching to ':require' instead of ':use'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ All of the API calls will return the full HTTP response of the request, includin
 
 ```clojure
 (ns mynamespace
-  (:use
-   [twitter.oauth]
-   [twitter.callbacks]
-   [twitter.callbacks.handlers]
-   [twitter.api.restful])
-  (:import
-   (twitter.callbacks.protocols SyncSingleCallback)))
+  (:require
+   [twitter
+    [oauth :refer :all]
+    [callbacks :refer :all]]
+   [twitter.callbacks.handlers :refer :all]
+   [twitter.api.restful :refer :all])
+  (:import [twitter.callbacks.protocols SyncSingleCallback]))
 
 (def my-creds (make-oauth-creds *app-consumer-key*
      			       		    *app-consumer-secret*
@@ -92,16 +92,15 @@ All of the API calls will return the full HTTP response of the request, includin
 
 ```clojure
 (ns mynamespace
-  (:use
-   [twitter.oauth]
-   [twitter.callbacks]
-   [twitter.callbacks.handlers]
-   [twitter.api.streaming])
   (:require
+   [twitter
+    [oauth :refer :all]
+    [callbacks :refer :all]]
+   [twitter.callbacks.handlers :refer :all]
+   [twitter.api.streaming :refer :all]
    [clojure.data.json :as json]
    [http.async.client :as ac])
-  (:import
-   (twitter.callbacks.protocols AsyncStreamingCallback)))
+  (:import [twitter.callbacks.protocols AsyncStreamingCallback]))
 
 (def my-creds (make-oauth-creds *app-consumer-key*
 			       		        *app-consumer-secret*

--- a/src/twitter/api.clj
+++ b/src/twitter/api.clj
@@ -1,6 +1,4 @@
-(ns twitter.api
-  (:use
-   [clojure.test]))
+(ns twitter.api)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -15,7 +13,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn make-uri 
+(defn make-uri
    "makes a uri from a supplied protocol, site, version and resource-path"
    [^ApiContext context
     ^String resource-path]

--- a/src/twitter/api/restful.clj
+++ b/src/twitter/api/restful.clj
@@ -1,8 +1,9 @@
 (ns twitter.api.restful
-  (:use
-   [twitter core callbacks api])
-  (:import
-   (twitter.api ApiContext)))
+  (:require [twitter
+             [api :refer :all]
+             [callbacks :refer :all]
+             [core :refer :all]]
+            [clojure.string :as str]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -15,8 +16,8 @@
 (defmacro def-twitter-restful-method
   [verb resource-path & rest]
   (let [json-path (str resource-path ".json") ; v1.1 is .json only.
-        dashed-name (clojure.string/replace resource-path #"[^a-zA-Z]+" "-") ; convert group of symbols to a dash 
-        clean-name (clojure.string/replace dashed-name #"-$" "") ; drop trailing dashes
+        dashed-name (str/replace resource-path #"[^a-zA-Z]+" "-") ; convert group of symbols to a dash
+        clean-name (str/replace dashed-name #"-$" "") ; drop trailing dashes
         fn-name (symbol clean-name)]
     `(def-twitter-method ~fn-name ~verb ~json-path :api ~*rest-api* :callbacks (get-default-callbacks :sync :single) ~@rest)))
 

--- a/src/twitter/api/search.clj
+++ b/src/twitter/api/search.clj
@@ -1,8 +1,8 @@
 (ns twitter.api.search
-  (:use
-   [twitter core callbacks])
-  (:import
-   (twitter.api ApiContext)))
+  (:require [twitter
+             [callbacks :refer :all]
+             [core :refer :all]])
+  (:import twitter.api.ApiContext))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/twitter/api/streaming.clj
+++ b/src/twitter/api/streaming.clj
@@ -1,8 +1,9 @@
 (ns twitter.api.streaming
-  (:use
-   [twitter core callbacks])
-  (:import
-   (twitter.api ApiContext)))
+  (:require
+   [twitter
+    [core :refer :all]
+    [callbacks :refer :all]])
+  (:import twitter.api.ApiContext))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/twitter/callbacks.clj
+++ b/src/twitter/callbacks.clj
@@ -1,11 +1,12 @@
 (ns twitter.callbacks
-  (:use
-   [twitter.callbacks handlers protocols])
-  (:require
-   [http.async.client :as ac])
-  (:import
-   (twitter.callbacks.protocols SyncSingleCallback SyncStreamingCallback
-                                AsyncSingleCallback AsyncStreamingCallback)))
+  (:require [twitter.callbacks
+             [handlers :refer :all]
+             [protocols :refer :all]])
+  (:import [twitter.callbacks.protocols
+            SyncSingleCallback
+            SyncStreamingCallback
+            AsyncSingleCallback
+            AsyncStreamingCallback]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/src/twitter/callbacks/protocols.clj
+++ b/src/twitter/callbacks/protocols.clj
@@ -1,9 +1,6 @@
 (ns twitter.callbacks.protocols
-  (:use
-   [twitter.callbacks.handlers])
-  (:require
-   [http.async.client :as ac]
-   [http.async.client.request :as req]))
+  (:require [twitter.callbacks.handlers :refer :all]
+            [http.async.client.request :as req]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/src/twitter/core.clj
+++ b/src/twitter/core.clj
@@ -1,14 +1,13 @@
 (ns twitter.core
-  (:use
-   [clojure.test]
-   [twitter callbacks oauth api utils request])
-  (:require
-   [clojure.data.json :as json]
-   [oauth.client :as oa]
-   [http.async.client :as ac]
-   [clojure.string :as string])
-  (:import
-   (clojure.lang Keyword PersistentArrayMap)))
+  (:require [clojure.string :as string]
+            [http.async.client :as ac]
+            [twitter
+             [api :refer :all]
+             [oauth :refer :all]
+             [request :refer :all]
+             [utils :refer :all]])
+  (:import [clojure.lang Keyword PersistentArrayMap]))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/twitter/oauth.clj
+++ b/src/twitter/oauth.clj
@@ -2,11 +2,13 @@
   (:require
    [http.async.client.request :as req]
    [http.async.client :refer [create-client]]
-   [twitter.callbacks :refer [callbacks-sync-single-default]]
-   [twitter.request :refer [execute-request-callbacks]]
    [clojure.data.codec.base64 :as b64]
-   [oauth.client :as oa]
-   [oauth.signature :as oas]))
+   [twitter
+    [callbacks :refer [callbacks-sync-single-default]]
+    [request :refer [execute-request-callbacks]]]
+   [oauth
+    [client :as oa]
+    [signature :as oas]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/twitter/oauth.clj
+++ b/src/twitter/oauth.clj
@@ -1,6 +1,4 @@
 (ns twitter.oauth
-  (:use
-   [clojure.test])
   (:require
    [http.async.client.request :as req]
    [http.async.client :refer [create-client]]
@@ -32,10 +30,10 @@
                                  verb
                                  uri
                                  query)))))
-  
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn oauth-header-string 
+(defn oauth-header-string
   "Creates the string for the oauth header's 'Authorization' value,
   url encoding each value. If the signing-map is an application-only
   token, returns the 'Bearer' value."
@@ -96,5 +94,5 @@
                                     "https://twitter.com/oauth/access_token"
                                     "https://twitter.com/oauth/authorize"
                                     :hmac-sha1)]
-     
+
      (OauthCredentials. consumer user-token user-token-secret))))

--- a/src/twitter/request.clj
+++ b/src/twitter/request.clj
@@ -8,9 +8,7 @@
    [http.async.client :as ac]
    [clojure.string :as string])
   (:import (com.ning.http.client Cookie
-                                 FluentCaseInsensitiveStringsMap
 				 PerRequestConfig
-                                 Request
                                  RequestBuilder)
            (com.ning.http.multipart StringPart
                                     FilePart)

--- a/src/twitter/request.clj
+++ b/src/twitter/request.clj
@@ -1,18 +1,17 @@
 (ns twitter.request
-  (:use
-   [twitter callbacks utils]
-   [twitter.callbacks protocols handlers])
   (:require
-   [http.async.client.util :as requ]
-   [http.async.client.request :as req]
+   [twitter.utils :refer :all]
+   [twitter.callbacks
+    [handlers :refer :all]
+    [protocols :refer :all]]
    [http.async.client :as ac]
+   [http.async.client
+    [util :as requ]
+    [request :as req]]
    [clojure.string :as string])
-  (:import (com.ning.http.client Cookie
-				 PerRequestConfig
-                                 RequestBuilder)
-           (com.ning.http.multipart StringPart
-                                    FilePart)
-           (java.io File InputStream)))
+  (:import [com.ning.http.client Cookie PerRequestConfig RequestBuilder]
+           [com.ning.http.multipart StringPart FilePart]
+           [java.io File InputStream]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Switched to using `:require` instead of `:use` in the namespaces.

This change mostly owes it to this commit: https://github.com/arrdem/twitter-api/commit/8005a0ec24f1b2338ff9af646a9e5851a69279c7 by @arrdem.

There were a few other things in there that @arrdem changed, like docstrings and comments. By I intentionally left them as is, not to shift too much stuff around. 

Maybe in the next PR I'll add in the changes as dictated by `cljfmt`: https://github.com/arrdem/twitter-api/commit/bec2edcd2e960440ee82ed15a06c8a14d647ca06.
